### PR TITLE
Fix MAF12 r_nonsep: a=1 returned 0, decoupling objectives from position variables

### DIFF
--- a/src/evox_ext/problems/neuroevolution/morobtrol_pro.py
+++ b/src/evox_ext/problems/neuroevolution/morobtrol_pro.py
@@ -510,7 +510,13 @@ class MoRobtrol(Problem):
             valid_mask=self.valid_mask,
         )
         self.key = key
-        rewards = self.reduce_fn(rewards, dim=-1)
+        if self.num_obj > 1:
+            # Multi-objective: rewards (pop, num_episodes, num_obj).
+            # Average over episodes only; the objective dim MUST be preserved.
+            # (torch.mean over dim=-1 would collapse the objectives into a scalar.)
+            rewards = rewards.mean(dim=1)
+        else:
+            rewards = self.reduce_fn(rewards, dim=-1)
         return rewards
 
     def visualize(

--- a/src/evox_ext/problems/numerical/lsmop.py
+++ b/src/evox_ext/problems/numerical/lsmop.py
@@ -61,7 +61,7 @@ class LSMOP(Problem):
         return self._pf_value
 
     def _calc_pf(self):
-        f = uniform_sampling(self.ref_num * self.m, self.m)[0] / 2
+        f = uniform_sampling(self.ref_num * self.m, self.m)[0]
         self._pf_value = f
 
     def _calc_X_(self, X: torch.Tensor):

--- a/src/evox_ext/problems/numerical/maf.py
+++ b/src/evox_ext/problems/numerical/maf.py
@@ -635,9 +635,12 @@ class MAF12(MAF):
             s2 = sum((Y - Y.roll(-o, dims=1)).abs().sum(dim=1) for o in range(1, a))
         else:
             s2 = torch.zeros_like(s1)
-        int_a2 = a // 2
+        int_a2 = (a + 1) // 2  # ceil(a/2)；a=1 时应为恒等（WFG r_nonsep 定义）
 
-        return (s1 + s2) / (Y.size(1) / a) * int_a2 * (1 + 2 * a - 2 * int_a2)
+        # 分母 = (M/a) * ceil(a/2) * (1 + 2a - 2*ceil(a/2))，与 evaluate 内
+        # last_col 的内联公式同构；旧实现误用 a//2 且把因子当乘子 → a=1 时恒 0，
+        # 使 MAF12 目标与位置变量脱钩（2026-09-09 修复）
+        return (s1 + s2) / (Y.size(1) / a) / (int_a2 * (1 + 2 * a - 2 * int_a2))
 
     def _concave(self, X: torch.Tensor):
         return torch.flip(

--- a/unit_test/problems/test_maf.py
+++ b/unit_test/problems/test_maf.py
@@ -54,3 +54,44 @@ class TestMAF(TestCase):
             pf = pro.pf()
             print(f"pf.size(): {pf.size()}")
             assert pf.size(1) == pro.m
+
+    def test_maf12_r_nonsep_identity(self):
+        """Regression test: _r_nonsep with a=1 must be the identity (WFG r_nonsep).
+
+        The old implementation used ``a // 2`` as a *multiplier*, which zeroes the
+        output for a=1. MAF12 applies it to the position variables, so the bug
+        decoupled the objectives from the position variables entirely and all
+        algorithms converged to the same degenerate front.
+        """
+        pro = MAF12(12, 3)
+        y = torch.tensor([[0.7], [0.2], [0.99]])
+        out = pro._r_nonsep(y, 1)
+        assert torch.allclose(out.flatten(), y.flatten(), atol=1e-6), (
+            f"a=1 must be identity, got {out}"
+        )
+
+    def test_maf12_r_nonsep_matches_inline_last_col(self):
+        """_r_nonsep(a=L) must agree with the inline last_col formula in evaluate.
+
+        evaluate() computes the aggregated distance column as
+        ``(sum + 2*SUM) / (L/2) / (1 + 2L - 2*(L/2))``; the helper must be
+        structurally consistent with it (they use the same normalization).
+        """
+        pro = MAF12(12, 3)
+        L = 10
+        torch.manual_seed(0)
+        y = torch.rand(3, L)
+        sum_ = y.sum(dim=1)
+        sum_pairs_once = (y.unsqueeze(2) - y.unsqueeze(1)).abs().sum(dim=(1, 2)) * 0.5
+        expected = (sum_ + 2 * sum_pairs_once) / (L / 2) / (1 + 2 * L - 2 * (L // 2))
+        assert torch.allclose(pro._r_nonsep(y, L), expected, atol=1e-6)
+
+    def test_maf12_objectives_depend_on_position_variables(self):
+        """Regression test: position variables must influence MAF12 objectives."""
+        pro = MAF12(12, 3)
+        X = torch.full((4, 12), 0.3)
+        X[:, :2] = 0.5
+        f1 = pro.evaluate(X)
+        X[:, :2] = 0.9
+        f2 = pro.evaluate(X)
+        assert not torch.allclose(f1, f2), "MAF12 objectives must depend on position variables"


### PR DESCRIPTION
## Problem

`MAF12._r_nonsep(Y, a)` used `a // 2` as a **multiplier** in the normalization factor:

```python
int_a2 = a // 2
return (s1 + s2) / (Y.size(1) / a) * int_a2 * (1 + 2 * a - 2 * int_a2)
```

For `a=1` (the identity case in the WFG `r_nonsep` definition), `int_a2` evaluates to 0, so the function **always returned 0**. MAF12 applies it to the position variables (`t3[:, :m-1]`, which get `_r_nonsep(y, 1)`), so those columns were always zero and the objectives became completely independent of the position variables — only the distance variables influenced the objectives through the single aggregated `last_col`.

**Symptom**: every algorithm converges to the same degenerate front from the very first generation. In our equal-FE benchmark runs, all four algorithms (RVEAa / NSGA-III / HypE / metaRVEA) produced **identical IGD on MAF12 across all 24 configurations and all 12 time windows** (e.g. m=3: everyone stuck at ~4.02, m=15: ~30.66), which is how the bug was discovered.

The existing unit test only asserts output *shapes*, so the bug passed CI.

## Fix

```python
int_a2 = (a + 1) // 2  # ceil(a/2)
return (s1 + s2) / (Y.size(1) / a) / (int_a2 * (1 + 2 * a - 2 * int_a2))
```

Two pieces of evidence that this is the correct formula:
1. `a=1` now restores identity: `_r_nonsep([[0.7],[0.2],[0.99]], 1) -> [0.7, 0.2, 0.99]` (per the WFG r_nonsep definition).
2. The corrected normalization is structurally identical to the **inline formula already present in `MAF12.evaluate()`** for `last_col` — `(sum + 2*SUM) / (L/2) / (1 + 2L - 2*(L/2))`. The old helper contradicted the inline code; they now agree.

## Verification

- Regression tests added (3 new, all passing):
  - `test_maf12_r_nonsep_identity`: `_r_nonsep(y, 1)` must be the identity
  - `test_maf12_r_nonsep_matches_inline_last_col`: `_r_nonsep(y, L)` agrees with `evaluate()`'s inline aggregation
  - `test_maf12_objectives_depend_on_position_variables`: changing position variables must change the objectives
- End-to-end: RVEAa on fixed MAF12 now shows a normal convergence trajectory (m=3: IGD 1.79 -> 0.44 over 100 generations; m=5: 4.59 -> 1.13) instead of a flat line from generation 1.
- Other MAF problems unaffected: only `MAF12.evaluate` calls `_r_nonsep`.

## Also included in this branch

Two earlier fixes on `dev-xbq` that were never merged to `main` (kept here intentionally for review together):
- `lsmop.py`: drop an incorrect halving in `_calc_pf` (reference front fix)
- `morobtrol_pro.py`: preserve objective dim in the MoRobtrol multi-objective reward reduction

## Impact

Any experiment using this `maf.py` for MAF12 is invalid — results showing "no difference between algorithms on MAF12" are the signature of this bug. (We have re-run our affected equal-FE experiments with the fix.)
